### PR TITLE
Update opentracing-openresty-0.1.rockspec

### DIFF
--- a/opentracing-openresty-0.1.rockspec
+++ b/opentracing-openresty-0.1.rockspec
@@ -2,7 +2,7 @@ package = "opentracing-openresty"
 version = "0.1-0"
 
 source = {
-    url = "git://github.com/iresty/opentracing-openresty.git",
+    url = "https://github.com/iresty/opentracing-openresty.git",
     tag = "v0.1",
 }
 


### PR DESCRIPTION
Update git protocol to https in accordance with new github security policy.

Similar to https://github.com/apache/apisix/issues/6074. I am trying to pull this dependency for nginx but its complaining about

```
bash-5.1# luarocks install opentracing-openresty
Installing https://luarocks.org/opentracing-openresty-0.1-0.rockspec
Cloning into 'opentracing-openresty'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
I realize that our versions is pretty old, but it's not feasible right now to upgrade luarocks package to 3.8.0
